### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This branch `2.17-326.el7` is for glibc version 2.17-326 included with RHEL/Cent
 
 * Set extra args for rpmbuild
 
-`RPMBUILD_EXTRAS="--define 'compatprefix /opt'" ./glibc-compatcollation.sh build`
+`BUILD_EXTRAS="--define 'compatprefix /opt'" ./glibc-compatcollation.sh build`
 
 ### For patch developers
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix env variable name in README to BUILD_EXTRAS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
