### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This branch `2.26-59.amzn2` is for glibc version 2.26-59 included with Amazon Li
 
 * Set extra args for rpmbuild
 
-`RPMBUILD_EXTRAS="--define 'compatprefix /opt'" ./glibc-compatcollation.sh build`
+`BUILD_EXTRAS="--define 'compatprefix /opt'" ./glibc-compatcollation.sh build`
 
 ### For patch developers
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix env variable name in README to BUILD_EXTRAS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
